### PR TITLE
Add gem installs needed to build and run specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Software development pairing management
 
 Clone into a new repo, cd into that folder
 
+Make sure Ruby/Rake/Sass are install
+```
+gem install rake
+gem install sass
+```
+
 ```
 $ npm install
 $ rake build


### PR DESCRIPTION
Was setting up on new Kubuntu image, only needed to install nodejs/npm (which I don't think needs to be in the readme).  Had to make sure rake was there (more obvious in hind site), but sass was one I wasn't expecting.  Everything seemed fine on Windows image, other than grunt seems to behave weird with Windows ([see last question](http://gruntjs.com/frequently-asked-questions)).  That is an issue outside this project though.

As amusing side note, took me longer than it should have to realize I didn't have Firefox installed as it tried to start it to run tests...