### PR TITLE
Prefer ./gradlew to gradle in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ Clone into a new repo, cd into that folder
 
 ```
 $ npm install
-$ gradle
+$ ./gradlew
 ```
+
+Note that `./gradlew` is preferred over the `gradle` command. Using `gradle` will fail with errors if the executable on your `$PATH` is newer than `2.13` or so, because of [the removal of StyledTextOutputFactory](https://discuss.gradle.org/t/bug-in-gradle-2-14-rc1-no-service-of-type-styledtextoutputfactory/17638) around version 2.14-rc1.
 
 **Before running tests make sure that a database called test exists**
 
@@ -34,14 +36,14 @@ $ gradle
 
 Build the static (JS and CSS) before attempting to run the application
 ```
-gradle jsBuild
+$ ./gradlew jsBuild
 ```
 
 _This assumes that you have a psql database on port 5432 with username pivotal and no password._
 
 If all of the tests pass, run the project as a spring project using your preferred method. To run the spring boot app locally using gradle, enter the following
 ```
-gradle bootRun
+$ ./gradlew bootRun
 ```
 
 # Want to contribute?
@@ -59,6 +61,6 @@ GOOGLE_ANALYTICS_TRACKING_ID=UA-XXXXXXXX-X
 # Deploy to CloudFoundry
 
 ```
-$ gradlew deploy
+$ ./gradlew deploy
 ```
 


### PR DESCRIPTION
I ran into some errors setting up the project; running `gradle --backtrace` produced this output:

```
FAILURE: Build failed with an exception.

* Where:
Build file '/Users/loaner/workspace/Parrit/build.gradle' line: 24

* What went wrong:
A problem occurred evaluating root project 'parrit'.
> Failed to apply plugin [class 'io.spring.gradle.dependencymanagement.DependencyManagementPlugin']
   > Could not create task of type 'DependencyManagementReportTask'.

<snip>

Caused by: org.gradle.internal.service.UnknownServiceException: No service of type StyledTextOutputFactory available in ProjectScopeServices.
        at org.gradle.internal.service.DefaultServiceRegistry.getServiceProvider(DefaultServiceRegistry.java:436)
        at org.gradle.internal.service.DefaultServiceRegistry.doGet(DefaultServiceRegistry.java:426)
        at org.gradle.internal.service.DefaultServiceRegistry.get(DefaultServiceRegistry.java:414)
        at org.gradle.api.internal.DependencyInjectingInstantiator.convertParameters(DependencyInjectingInstantiator.java:81)
        at org.gradle.api.internal.DependencyInjectingInstantiator.newInstance(DependencyInjectingInstantiator.java:54)
        at org.gradle.api.internal.ClassGeneratorBackedInstantiator.newInstance(ClassGeneratorBackedInstantiator.java:36)
        at org.gradle.api.internal.project.taskfactory.TaskFactory$1.call(TaskFactory.java:121)
```

It looks like newer versions of Gradle don't have StyledTextOutputFactory, on which the dependency management plugin depends.

This PR suggests using `./gradlew` instead of `gradle` in the README to lock the Gradle version.