### PR TITLE
Add a button to move all pairs to "floating"

### DIFF
--- a/src/main/js/project/actions/appActions.js
+++ b/src/main/js/project/actions/appActions.js
@@ -6,6 +6,10 @@ function movePersonCombo(...args) {
     return dataThunks.autoSaveThunk(dataCreators.movePersonCreator(...args));
 }
 
+function resetPairingBoard() {
+    return dataThunks.autoSaveThunk(dataCreators.resetPairingBoard());
+}
+
 function createPairingBoardCombo(...args) {
     return dataThunks.autoSaveThunk(dataCreators.createPairingBoardCreator(...args));
 }
@@ -24,6 +28,7 @@ function renamePairingBoardCombo(...args) {
 
 module.exports = {
     movePerson: movePersonCombo,
+    resetPairs: resetPairingBoard,
     createPerson: dataThunks.addNewPersonThunk,
     createPairingBoard: createPairingBoardCombo,
     deletePerson: deletePersonCombo,

--- a/src/main/js/project/actions/creators/dataCreators.js
+++ b/src/main/js/project/actions/creators/dataCreators.js
@@ -7,6 +7,12 @@ export function movePersonCreator(fromPairingBoardIndex, toPairingBoardIndex, pe
     };
 }
 
+export function resetPairingBoard() {
+    return {
+        type: 'RESET_PAIRING_BOARD'
+    };
+}
+
 export function createPersonCreator(name) {
     return {
         type: 'CREATE_PERSON',

--- a/src/main/js/project/components/App.js
+++ b/src/main/js/project/components/App.js
@@ -14,6 +14,7 @@ var App = React.createClass({
 
         savePairing: React.PropTypes.func.isRequired,
         getRecommendedPairs: React.PropTypes.func.isRequired,
+        resetPairs: React.PropTypes.func.isRequired,
         settings: React.PropTypes.object.isRequired,
         data: React.PropTypes.object.isRequired,
         setNewPersonModalOpen: React.PropTypes.func.isRequired,
@@ -104,6 +105,7 @@ var App = React.createClass({
         var projectProps = {
             savePairing: this.props.savePairing,
             getRecommendedPairs: this.props.getRecommendedPairs,
+            resetPairs: this.props.resetPairs,
             settings: this.props.settings,
             data: this.props.data,
             setNewPersonModalOpen: this.props.setNewPersonModalOpen,

--- a/src/main/js/project/components/Project.js
+++ b/src/main/js/project/components/Project.js
@@ -7,6 +7,7 @@ var Project = React.createClass({
     propTypes: {
         savePairing: React.PropTypes.func.isRequired,
         getRecommendedPairs: React.PropTypes.func.isRequired,
+        resetPairs: React.PropTypes.func.isRequired,
 
         settings: React.PropTypes.object.isRequired,
         data: React.PropTypes.object.isRequired,
@@ -38,6 +39,7 @@ var Project = React.createClass({
             <div className="sub-header">
                 <h1 className="project-name">{this.props.data.project.name}</h1>
                 <div className="project-actions">
+                    <Button className="button-blue" name="Reset Pairs" shortName="Reset" clickFunction={this.props.resetPairs} />
                     <Button className="button-blue" name="Recommend Pairs" shortName="Recommend" clickFunction={this.props.getRecommendedPairs}/>
                     <Button className="button-green" name="Record Pairs" shortName="Record" clickFunction={this.props.savePairing}/>
                 </div>

--- a/src/main/js/project/reducers/projectReducer.js
+++ b/src/main/js/project/reducers/projectReducer.js
@@ -21,6 +21,22 @@ var projectReducer = function(state, action) {
             toPairingBoard.people.push(_.pullAt(fromPairingBoard.people, action.personIndex)[0]);
 
             return stateClone;
+        case "RESET_PAIRING_BOARD":
+            var stateClone = _.cloneDeep(state);
+            
+            // forEach pairing board
+                // take people array
+                // set people array to []
+            // take all people and append to "people"
+            stateClone.people = stateClone.people.concat(
+                stateClone.pairingBoards.reduce(function( people, pairingBoard ) {
+                    people = people.concat( pairingBoard.people );
+                    pairingBoard.people = [];
+                    return people;
+                }, [])
+            );
+            
+            return stateClone;
         case "CREATE_PERSON":
             var stateClone = _.cloneDeep(state);
 

--- a/src/main/resources/static/sass/imports/project.scss
+++ b/src/main/resources/static/sass/imports/project.scss
@@ -21,6 +21,10 @@
       .project-actions {
         button {
           padding: 0 20px;
+          margin-right: 15px;
+          &:last-child {
+            margin-right: 0;
+          }
         }
       }
     }
@@ -55,8 +59,10 @@
         .project-actions {
           margin-top: 23px;
 
-          button:first-child {
-            margin-right: 10px;
+          button {
+            float: left;
+            clear: left;
+            margin: 5px 10px 0 15px;
           }
         }
       }
@@ -114,10 +120,6 @@
       .project-actions {
         float: right;
         margin-top: 32px;
-
-        button:first-child {
-          margin-right: 15px;
-        }
       }
     }
 

--- a/src/test/js/project/components/AppSpec.js
+++ b/src/test/js/project/components/AppSpec.js
@@ -18,6 +18,7 @@ describe('App', function() {
     var props = {
         getRecommendedPairs: function(){},
         savePairing: function(){},
+        resetPairs: function(){},
 
         settings: {
             isPairingHistoryPanelOpen: true

--- a/src/test/js/project/components/ProjectSpec.js
+++ b/src/test/js/project/components/ProjectSpec.js
@@ -14,6 +14,7 @@ describe('Project', function() {
     var props = {
         getRecommendedPairs: function(){},
         savePairing: function(){},
+        resetPairs: function(){},
 
         settings: {},
         data: {
@@ -52,9 +53,18 @@ describe('Project', function() {
         expect(projectName.innerHTML).toBe('The Best Around');
     });
 
-    it('has a recommend pairs button', function() {
+    it('has a reset pairs button', function() {
         var allButtons = ReactTestUtils.scryRenderedComponentsWithType(project, ButtonMock);
         var recommendPairsButton = allButtons[0];
+
+        expect(recommendPairsButton.props.className).toBe('button-blue');
+        expect(recommendPairsButton.props.name).toBe('Reset Pairs');
+        expect(recommendPairsButton.props.shortName).toBe('Reset');
+        expect(recommendPairsButton.props.clickFunction).toBe(props.resetPairs);
+    });
+    it('has a recommend pairs button', function() {
+        var allButtons = ReactTestUtils.scryRenderedComponentsWithType(project, ButtonMock);
+        var recommendPairsButton = allButtons[1];
 
         expect(recommendPairsButton.props.className).toBe('button-blue');
         expect(recommendPairsButton.props.name).toBe('Recommend Pairs');
@@ -64,7 +74,7 @@ describe('Project', function() {
 
     it('has a records pairs button', function() {
         var allButtons = ReactTestUtils.scryRenderedComponentsWithType(project, ButtonMock);
-        var recordPairs = allButtons[1];
+        var recordPairs = allButtons[2];
 
         expect(recordPairs.props.className).toBe('button-green');
         expect(recordPairs.props.name).toBe('Record Pairs');

--- a/src/test/js/project/reducers/projectReducerSpec.js
+++ b/src/test/js/project/reducers/projectReducerSpec.js
@@ -177,6 +177,57 @@ describe("projectReducer", function () {
             });
         });
 
+        describe('RESET_PAIRING_BOARD', function() {
+            it('moves all people from pairing boards to floating', function() {
+                var stateBefore = {
+                    id: 7,
+                    people: [{name: "Bubba Gump"}],
+                    pairingBoards: [
+                        {
+                            name: "BOARD1",
+                            people: [{name:"Charles Shaw"}]
+                        },
+                        {
+                            name: "BOARD2",
+                            people: [
+                                {name: "Hanzle"},
+                                {name: "Gretel"}
+                            ]
+                        }
+                    ]
+                };
+                
+                var action = { type: 'RESET_PAIRING_BOARD' };
+                
+                var stateAfter = {
+                    id: 7,
+                    people: [
+                        {name: "Bubba Gump"},
+                        {name:"Charles Shaw"},
+                        {name: "Hanzle"},
+                        {name: "Gretel"}
+                    ],
+                    pairingBoards: [
+                        {
+                            name: "BOARD1",
+                            people: []
+                        },
+                        {
+                            name: "BOARD2",
+                            people: []
+                        }
+                    ]
+                };
+                
+                deepFreeze(stateBefore);
+                deepFreeze(action);
+                
+                expect(
+                    projectReducer(stateBefore, action)
+                ).toEqual(stateAfter);
+            });
+        });
+
         describe('CREATE_PERSON', function () {
             it('adds a person to the project', function () {
                 var stateBefore = {


### PR DESCRIPTION
Closes #22 

Adds an extra button to the project view to move all people into the "floating section"
It looks like the mobile CSS needs some love. The buttons were laying out strangely so I just made them all float left one after another.

Made with love during [Hacktoberfest](https://hacktoberfest.digitalocean.com/) at [Fullstack LA](http://www.meetup.com/la-fullstack/events/234620974/)!