### PR TITLE
Exempt boards are not cleared when Reset Pairs is clicked

### DIFF
--- a/src/main/js/project/reducers/projectReducer.js
+++ b/src/main/js/project/reducers/projectReducer.js
@@ -23,19 +23,22 @@ var projectReducer = function(state, action) {
             return stateClone;
         case "RESET_PAIRING_BOARD":
             var stateClone = _.cloneDeep(state);
-            
+
             // forEach pairing board
                 // take people array
                 // set people array to []
             // take all people and append to "people"
+						// unless the board is an exempt board
             stateClone.people = stateClone.people.concat(
                 stateClone.pairingBoards.reduce(function( people, pairingBoard ) {
+										if (pairingBoard.exempt) return people;
+
                     people = people.concat( pairingBoard.people );
                     pairingBoard.people = [];
                     return people;
                 }, [])
             );
-            
+
             return stateClone;
         case "CREATE_PERSON":
             var stateClone = _.cloneDeep(state);

--- a/src/test/js/project/reducers/projectReducerSpec.js
+++ b/src/test/js/project/reducers/projectReducerSpec.js
@@ -218,7 +218,66 @@ describe("projectReducer", function () {
                         }
                     ]
                 };
-                
+
+                deepFreeze(stateBefore);
+                deepFreeze(action);
+
+                expect(
+                    projectReducer(stateBefore, action)
+                ).toEqual(stateAfter);
+            });
+
+            it('does not move people on exempt pairing boards to floating', function() {
+                var stateBefore = {
+                    id: 7,
+                    people: [{name: "Bubba Gump"}],
+                    pairingBoards: [
+                        {
+                            name: "BOARD1",
+                            people: [{name:"Charles Shaw"}]
+                        },
+                        {
+                            name: "BOARD2",
+                            people: [
+                                {name: "Hansel"},
+                                {name: "Gretel"}
+                            ]
+                        },
+                        {
+                          name: "OOO",
+                          exempt: true,
+                          people: [{name: "Rip van Winkle"}]
+                        }
+                    ]
+                };
+
+                var action = { type: 'RESET_PAIRING_BOARD' };
+
+                var stateAfter = {
+                    id: 7,
+                    people: [
+                        {name: "Bubba Gump"},
+                        {name:"Charles Shaw"},
+                        {name: "Hansel"},
+                        {name: "Gretel"}
+                    ],
+                    pairingBoards: [
+                        {
+                            name: "BOARD1",
+                            people: []
+                        },
+                        {
+                            name: "BOARD2",
+                            people: []
+                        },
+                        {
+                          name: "OOO",
+                          exempt: true,
+                          people: [{name: "Rip van Winkle"}]
+                        }
+                    ]
+                };
+
                 deepFreeze(stateBefore);
                 deepFreeze(action);
                 


### PR DESCRIPTION
I love the Reset Pairs button, but the first time I used it I was surprised that the Out of Office board got cleared. This change prevents Reset Pairs from clearing boards that are marked `exempt`.